### PR TITLE
Use string instead of GeneralEmailResponse

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -360,18 +360,11 @@ var email = new EmailMessage
 };
 await emailService.SendAsync(email);
 ```
-Both methods return response (SendAsync - `GeneralEmailResponse`; SendBulkAsync - `List<GeneralEmailResponse>`) when you use them while sending email.
-If you set a variable to the call, you will be able to use returned response.
+Both methods return response (SendAsync - `string`; SendBulkAsync - `List<string>`) when you use them while sending email.
+If you set a variable to the call, you will be able to use returned response. Response structure varies on different email providers, so you can create your ouw return type and map returned string into it.
 
-```csharp
-public class GeneralEmailResponse
-{
-    public string Status { get; set; } = null!;
-    public string Code { get; set; } = null!;
-    public string TrackingId { get; set; } = null!;
-    public string Id { get; set; } = null!;
-    public string Service { get; set; } = null!;
-}
+```text
+2.0.0 OK 8ONXSST18NU4.DSCFVS8PQ0Q13@test AM0PR08MB5346.eurprd08.prod.outlook.com
 ```
 
 ## 1.6. Limitations

--- a/src/Communicator/Communicator.csproj
+++ b/src/Communicator/Communicator.csproj
@@ -8,7 +8,7 @@
         <PackageReadmeFile>Readme.md</PackageReadmeFile>
         <Authors>Pandatech</Authors>
         <Copyright>MIT</Copyright>
-        <Version>1.0.4</Version>
+        <Version>1.0.5</Version>
         <PackageId>Pandatech.Communicator</PackageId>
         <Title>SMS and Email Communication helper</Title>
         <PackageTags>Pandatech, library, Sms, Email, Messages</PackageTags>

--- a/src/Communicator/Services/Implementations/EmailService.cs
+++ b/src/Communicator/Services/Implementations/EmailService.cs
@@ -13,7 +13,7 @@ internal class EmailService(CommunicatorOptions options)
 {
     private EmailConfiguration _emailConfiguration = null!;
     
-    public async Task<GeneralEmailResponse> SendAsync(EmailMessage emailMessage, CancellationToken cancellationToken = default)
+    public async Task<string> SendAsync(EmailMessage emailMessage, CancellationToken cancellationToken = default)
     {
         EmailMessageValidator.Validate(emailMessage);
         
@@ -21,9 +21,9 @@ internal class EmailService(CommunicatorOptions options)
         return await SendEmailAsync(message, cancellationToken);
     }
 
-    public async Task<List<GeneralEmailResponse>> SendBulkAsync(List<EmailMessage> emailMessages, CancellationToken cancellationToken = default)
+    public async Task<List<string>> SendBulkAsync(List<EmailMessage> emailMessages, CancellationToken cancellationToken = default)
     {
-        var responses = new List<GeneralEmailResponse>();
+        var responses = new List<string>();
         
         foreach (var emailMessage in emailMessages)
         {
@@ -80,7 +80,7 @@ internal class EmailService(CommunicatorOptions options)
         return message;
     }
 
-    private async Task<GeneralEmailResponse> SendEmailAsync(MimeMessage message, CancellationToken cancellationToken)
+    private async Task<string> SendEmailAsync(MimeMessage message, CancellationToken cancellationToken)
     {
         using var smtpClient = new SmtpClient();
         smtpClient.Timeout = _emailConfiguration.TimeoutMs;
@@ -91,7 +91,7 @@ internal class EmailService(CommunicatorOptions options)
         var response = await smtpClient.SendAsync(message, cancellationToken);
         await smtpClient.DisconnectAsync(true, cancellationToken);
 
-        return GeneralEmailResponse.Parse(response);
+        return response;
     }
 
     private EmailConfiguration GetEmailConfigurationByChannel(string channel)

--- a/src/Communicator/Services/Implementations/FakeEmailService.cs
+++ b/src/Communicator/Services/Implementations/FakeEmailService.cs
@@ -8,26 +8,27 @@ namespace Communicator.Services.Implementations;
 
 internal class FakeEmailService(ILogger<FakeEmailService> logger) : IEmailService
 {
-    public Task<GeneralEmailResponse> SendAsync(EmailMessage emailMessage, CancellationToken cancellationToken = default)
+    public Task<string> SendAsync(EmailMessage emailMessage, CancellationToken cancellationToken = default)
     {
         EmailMessageValidator.Validate(emailMessage);
 
         logger.LogCritical("Email sent to {Recipient}\n Email subject is {Subject} \n Email body is {Body}",
             emailMessage.Recipients, emailMessage.Subject, emailMessage.Body);
-        
-        return Task.FromResult(new GeneralEmailResponse());
+
+        return Task.FromResult("2.0.0 OK");
     }
 
-    public Task<List<GeneralEmailResponse>> SendBulkAsync(List<EmailMessage> emailMessages, CancellationToken cancellationToken = default)
+    public Task<List<string>> SendBulkAsync(List<EmailMessage> emailMessages,
+        CancellationToken cancellationToken = default)
     {
         foreach (var emailMessage in emailMessages)
         {
             EmailMessageValidator.Validate(emailMessage);
-            
+
             logger.LogCritical("Email sent to {Recipient} \n Email subject is {Subject} \n Email body is {Body}",
                 emailMessage.Recipients, emailMessage.Subject, emailMessage.Body);
         }
 
-        return Task.FromResult(new List<GeneralEmailResponse>());
+        return Task.FromResult(new List<string>() { "2.0.0 OK" });
     }
 }

--- a/src/Communicator/Services/Interfaces/IEmailService.cs
+++ b/src/Communicator/Services/Interfaces/IEmailService.cs
@@ -5,6 +5,6 @@ namespace Communicator.Services.Interfaces;
 
 public interface IEmailService
 {
-    Task<GeneralEmailResponse> SendAsync(EmailMessage emailMessage, CancellationToken cancellationToken = default);
-    Task<List<GeneralEmailResponse>> SendBulkAsync(List<EmailMessage> emailMessages, CancellationToken cancellationToken = default);
+    Task<string> SendAsync(EmailMessage emailMessage, CancellationToken cancellationToken = default);
+    Task<List<string>> SendBulkAsync(List<EmailMessage> emailMessages, CancellationToken cancellationToken = default);
 }

--- a/test/Communicator.Demo/Program.cs
+++ b/test/Communicator.Demo/Program.cs
@@ -8,53 +8,66 @@ using Communicator.Services.Interfaces;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.AddCommunicator();
-builder.AddCommunicator(options =>
-{
-    options.SmsFake = false;
-    options.SmsConfigurations = new Dictionary<string, SmsConfiguration>
-    {
-        {
-            "GeneralSender", new SmsConfiguration
-            {
-                Provider = "Dexatel",
-                From = "sender_name",
-                Properties = new Dictionary<string, string>
-                {
-                    { "X-Dexatel-Key", "key" }
-                },
-                TimeoutMs = 10000
-            }
-        }
-    };
-    options.EmailFake = false;
-    options.EmailConfigurations = new Dictionary<string, EmailConfiguration>
-    {
-        {
-            "GeneralSender", new EmailConfiguration
-            {
-                SmtpServer = "smtp-mail.outlook.com",
-                SmtpPort = 587, // 587
-                SmtpUsername = "easybot@easypay.am",
-                SmtpPassword = "rbmpbzsytkvqfzdv",
-                SenderEmail = "easybot@easypay.am",
-                UseSsl = false, // false
-                TimeoutMs = 10000
-            }
-        },
-        {
-            "TransactionalSender", new EmailConfiguration
-            {
-                SmtpServer = "smtp.gmail.com",
-                SmtpPort = 465, // 587
-                SmtpUsername = "ruboarm@gmail.com",
-                SmtpPassword = "uqihfffvqfngeczq",
-                SenderEmail = "ruboarm@gmail.com",
-                UseSsl = true, // false
-                TimeoutMs = 10000
-            }
-        }
-    };
-});
+// builder.AddCommunicator(options =>
+// {
+//     options.SmsFake = false;
+//     options.SmsConfigurations = new Dictionary<string, SmsConfiguration>
+//     {
+//         {
+//             "GeneralSender", new SmsConfiguration
+//             {
+//                 Provider = "Dexatel",
+//                 From = "sender_name",
+//                 Properties = new Dictionary<string, string>
+//                 {
+//                     { "X-Dexatel-Key", "key" }
+//                 },
+//                 TimeoutMs = 10000
+//             }
+//         },
+//         {
+//             "TransactionalSender", new SmsConfiguration
+//             {
+//                 Provider = "Twilio",
+//                 From = "sender_number",
+//                 Properties = new Dictionary<string, string>
+//                 {
+//                     { "SID", "key" },
+//                     { "AUTH_TOKEN", "token" }
+//                 },
+//                 TimeoutMs = 10000
+//             }
+//         }
+//     };
+//     options.EmailFake = false;
+//     options.EmailConfigurations = new Dictionary<string, EmailConfiguration>
+//     {
+//         {
+//             "GeneralSender2", new EmailConfiguration
+//             {
+//                 SmtpServer = "smtp.test.com",
+//                 SmtpPort = 465, // 587
+//                 SmtpUsername = "test",
+//                 SmtpPassword = "test123",
+//                 SenderEmail = "test@test.com",
+//                 UseSsl = true, // false
+//                 TimeoutMs = 10000
+//             }
+//         },
+//         {
+//             "TransactionalSender", new EmailConfiguration
+//             {
+//                 SmtpServer = "smtp.gmail.com",
+//                 SmtpPort = 465, // 587
+//                 SmtpUsername = "vazgen",
+//                 SmtpPassword = "vazgen123",
+//                 SenderEmail = "vazgencho@gmail.com",
+//                 UseSsl = true, // false
+//                 TimeoutMs = 10000
+//             }
+//         }
+//     };
+// });
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();

--- a/test/Communicator.Demo/Program.cs
+++ b/test/Communicator.Demo/Program.cs
@@ -8,66 +8,53 @@ using Communicator.Services.Interfaces;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.AddCommunicator();
-// builder.AddCommunicator(options =>
-// {
-//     options.SmsFake = false;
-//     options.SmsConfigurations = new Dictionary<string, SmsConfiguration>
-//     {
-//         {
-//             "GeneralSender", new SmsConfiguration
-//             {
-//                 Provider = "Dexatel",
-//                 From = "sender_name",
-//                 Properties = new Dictionary<string, string>
-//                 {
-//                     { "X-Dexatel-Key", "key" }
-//                 },
-//                 TimeoutMs = 10000
-//             }
-//         },
-//         {
-//             "TransactionalSender", new SmsConfiguration
-//             {
-//                 Provider = "Twilio",
-//                 From = "sender_number",
-//                 Properties = new Dictionary<string, string>
-//                 {
-//                     { "SID", "key" },
-//                     { "AUTH_TOKEN", "token" }
-//                 },
-//                 TimeoutMs = 10000
-//             }
-//         }
-//     };
-//     options.EmailFake = false;
-//     options.EmailConfigurations = new Dictionary<string, EmailConfiguration>
-//     {
-//         {
-//             "GeneralSender2", new EmailConfiguration
-//             {
-//                 SmtpServer = "smtp.test.com",
-//                 SmtpPort = 465, // 587
-//                 SmtpUsername = "test",
-//                 SmtpPassword = "test123",
-//                 SenderEmail = "test@test.com",
-//                 UseSsl = true, // false
-//                 TimeoutMs = 10000
-//             }
-//         },
-//         {
-//             "TransactionalSender", new EmailConfiguration
-//             {
-//                 SmtpServer = "smtp.gmail.com",
-//                 SmtpPort = 465, // 587
-//                 SmtpUsername = "vazgen",
-//                 SmtpPassword = "vazgen123",
-//                 SenderEmail = "vazgencho@gmail.com",
-//                 UseSsl = true, // false
-//                 TimeoutMs = 10000
-//             }
-//         }
-//     };
-// });
+builder.AddCommunicator(options =>
+{
+    options.SmsFake = false;
+    options.SmsConfigurations = new Dictionary<string, SmsConfiguration>
+    {
+        {
+            "GeneralSender", new SmsConfiguration
+            {
+                Provider = "Dexatel",
+                From = "sender_name",
+                Properties = new Dictionary<string, string>
+                {
+                    { "X-Dexatel-Key", "key" }
+                },
+                TimeoutMs = 10000
+            }
+        }
+    };
+    options.EmailFake = false;
+    options.EmailConfigurations = new Dictionary<string, EmailConfiguration>
+    {
+        {
+            "GeneralSender", new EmailConfiguration
+            {
+                SmtpServer = "smtp-mail.outlook.com",
+                SmtpPort = 587, // 587
+                SmtpUsername = "easybot@easypay.am",
+                SmtpPassword = "rbmpbzsytkvqfzdv",
+                SenderEmail = "easybot@easypay.am",
+                UseSsl = false, // false
+                TimeoutMs = 10000
+            }
+        },
+        {
+            "TransactionalSender", new EmailConfiguration
+            {
+                SmtpServer = "smtp.gmail.com",
+                SmtpPort = 465, // 587
+                SmtpUsername = "ruboarm@gmail.com",
+                SmtpPassword = "uqihfffvqfngeczq",
+                SenderEmail = "ruboarm@gmail.com",
+                UseSsl = true, // false
+                TimeoutMs = 10000
+            }
+        }
+    };
+});
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
@@ -121,7 +108,7 @@ app.MapGet("/send/email-and-sms/multiple-recipients", async (IEmailService email
     return Results.Ok("Email and SMS sent successfully.");
 });
 
-app.MapGet("/send/email/html-body", async (IEmailService emailService) =>
+app.MapGet("/send/email/html-body/outlook", async (IEmailService emailService) =>
 {
     var email = new EmailMessage
     {
@@ -135,7 +122,21 @@ app.MapGet("/send/email/html-body", async (IEmailService emailService) =>
     return Results.Ok("Email sent successfully.");
 });
 
-app.MapGet("/send/email/html-body/with-response", async (IEmailService emailService) =>
+app.MapGet("/send/email/html-body/gmail", async (IEmailService emailService) =>
+{
+    var email = new EmailMessage
+    {
+        Recipients = ["a@a.com"],
+        Subject = "Some subject",
+        Body = EmailTemplates.AddEmailAddressTemplate("Test", "Test", "https://www.google.com/"),
+        IsBodyHtml = true,
+        Channel = EmailChannels.TransactionalSender
+    };
+    await emailService.SendAsync(email);
+    return Results.Ok("Email sent successfully.");
+});
+
+app.MapGet("/send/email/html-body/with-response/outlook", async (IEmailService emailService) =>
 {
     var email = new EmailMessage
     {
@@ -144,6 +145,20 @@ app.MapGet("/send/email/html-body/with-response", async (IEmailService emailServ
         Body = EmailTemplates.AddEmailAddressTemplate("Test", "Test", "https://www.google.com/"),
         IsBodyHtml = true,
         Channel = EmailChannels.GeneralSender
+    };
+    var response = await emailService.SendAsync(email);
+    return Results.Ok(response);
+});
+
+app.MapGet("/send/email/html-body/with-response/gmail", async (IEmailService emailService) =>
+{
+    var email = new EmailMessage
+    {
+        Recipients = ["a@a.com"],
+        Subject = "Some subject",
+        Body = EmailTemplates.AddEmailAddressTemplate("Test", "Test", "https://www.google.com/"),
+        IsBodyHtml = true,
+        Channel = EmailChannels.TransactionalSender
     };
     var response = await emailService.SendAsync(email);
     return Results.Ok(response);


### PR DESCRIPTION
Remove "**GeneralEmailResponse**" from usage for general use, as email providers responses can differ from each other.